### PR TITLE
cando is a protected variable. use canDo function instead

### DIFF
--- a/helper.php
+++ b/helper.php
@@ -52,7 +52,7 @@ class helper_plugin_editor extends DokuWiki_Plugin {
         } elseif ($user{0} == '@') {                                           // filter group
             global $auth;
 
-            if (($auth) && ($auth->cando['getUsers'])) {
+            if (($auth) && ($auth->canDo('getUsers'))) {
                 $user = $auth->retrieveUsers(0, 0, array('grps' => substr($user, 1)));
                 $user = array_keys($user);
                 $type = 'group';


### PR DESCRIPTION
In the latest version of DokuWiki, and possibly since some earlier versions, the 'cando' variable is protected. Therefore, you need to use the 'canDo' function instead to check if the variable is set. This requires only a minor change (note the capitalization and parenthesis instead of square brackets).
